### PR TITLE
ansible-ci-module の追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "gitsubmodule"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    time: "02:00"
+    timezone: "Asia/Tokyo"
+  reviewers:
+    - "y-hashida"

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+      fail-fast: False
     steps:
       - name: Install LXD and CI tools
         run: |

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -1,0 +1,59 @@
+name: ansible ci
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - v*
+
+jobs:
+  create-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Install pip3 and tox
+        run: |
+          sudo apt update
+          sudo apt -y install python3 python3-pip python3-setuptools
+          sudo pip3 install tox
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Create tox env list
+        id: set-matrix
+        run: |
+          TOX_ENV=$(python3 ansible-ci-module/scripts/toxenv_to_json.py)
+          echo "::set-output name=matrix::{\"tox_env\":[${TOX_ENV}]}"
+
+  ansible-ci:
+    needs: create-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+    steps:
+      - name: Install LXD and CI tools
+        run: |
+          sudo apt update
+          sudo apt install lxd lxd-tools qemu-block-extra python3 python3-pip python3-setuptools
+
+      - name: Configure LXD
+        run: |
+          sudo lxd init --auto
+
+      - name: Install tox using python3-pip
+        run: |
+          sudo pip3 install tox
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: ansible-ci
+        run: |
+          sudo tox -e ${{ matrix.tox_env }} -c ansible-ci-module/tox.ini

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   ansible-ci:
     needs: create-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ansible-ci-module"]
+	path = ansible-ci-module
+	url = https://github.com/link-u/ansible-ci-module.git

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,6 +6,9 @@
   template:
     src: config.xml.j2
     dest: /etc/clickhouse-server/config.xml
+    owner: "root"
+    group: "root"
+    mode: "0644"
   notify: Restart clickhouse-server
   when:
     - not clickhouse_install_client_only
@@ -14,6 +17,9 @@
   template:
     src: users.xml.j2
     dest: /etc/clickhouse-server/users.xml
+    owner: "root"
+    group: "root"
+    mode: "0644"
   notify: Restart clickhouse-server
   when:
     - not clickhouse_install_client_only

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -74,18 +74,11 @@
   apt_repository:
     repo: deb http://repo.yandex.ru/clickhouse/deb/stable/ main/
     state: present
-  register: __clickhouse_add_apt_repo
-
-- name: Update apt repository
-  apt:
-    update_cache: yes
-  when: __clickhouse_add_apt_repo.changed | bool
 
 - name: Install clickhouse-server
   apt:
-    pkg: clickhouse-server
+    name: clickhouse-server
     update_cache: yes
-    cache_valid_time: 86400
   when:
     - not clickhouse_install_client_only
 
@@ -93,4 +86,3 @@
   apt:
     pkg: clickhouse-client
     update_cache: yes
-    cache_valid_time: 86400

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,6 +2,12 @@
 # defaults/install.yml (clickhouse)
 # Prefix : clickhouse
 
+- name: Pre-install packages
+  apt:
+    name: "gpg"
+    state: present
+    update_cache: yes
+
 # FIXME(Ryo Hirafuji): ansible2.4からの不具合により、
 # プロキシの下では以下が失敗する
 # https://github.com/ansible/ansible/issues/31691


### PR DESCRIPTION
### 変更点

* ansible-ci-module の追加
* このプルリクでできる CI について
  * ansible-lint による linting
  * molecule による各環境ごとのインストールテスト

* このプルリクではまだ未実装の CI について
  * testinfra による verify
    ※ これは別のプルリクで実装する予定.
