### PR TITLE
Prometheus向けの設定を追加した

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ clickhouse_http_port: 8123              # web からの clickhouse アクセス�
 clickhouse_tcp_port: 9000               # clickhouse-client からのアクセス用ポート
 clickhouse_mysql_port: 9004             # mysql-client からのアクセス用ポート
 clickhouse_interserver_http_port: 9009  # clickhouse クラスタのノード間でデータを交換するためのポート
+clickhouse_prometheus_port: 8001        # Prometheus向けのmetricsを公開するためのポート
 clickhouse_logger_log: /var/log/clickhouse-server/clickhouse-server.log
 clickhouse_logger_errorlog: /var/log/clickhouse-server/clickhouse-server.err.log
 clickhouse_data_dir: /var/lib/clickhouse/      # ※ パス最後のスラッシュは残すこと

--- a/templates/config.xml.j2
+++ b/templates/config.xml.j2
@@ -9,6 +9,14 @@
         <count>10</count>
         <!-- <console>1</console> --> <!-- Default behavior is autodetection (log to console if not daemon mode and is tty) -->
     </logger>
+     <prometheus>
+        <!-- See: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server_configuration_parameters-prometheus -->
+        <endpoint>/metrics</endpoint>
+        <port>{{ clickhouse_prometheus_port }}</port>
+        <metrics>true</metrics>
+        <events>true</events>
+        <asynchronous_metrics>true</asynchronous_metrics>
+    </prometheus>
     <!--display_name>production</display_name--> <!-- It is the name that will be shown in the client -->
     <http_port>{{ clickhouse_http_port }}</http_port>
     <tcp_port>{{ clickhouse_tcp_port }}</tcp_port>


### PR DESCRIPTION
ClickhouseがPrometheusのために内部的にHTTPサーバを建てる機能があるんですが、そのための設定項目を追加しました。